### PR TITLE
- Attempt to fix recent 'loss of npm' issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,9 @@ RUN apt-get install -y wget gnupg bzip2
 # Add in the frontend code
 RUN git clone https://github.com/xchem/fragalysis-frontend ${APP_ROOT}/frontend
 # Now add npm
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install -y nodejs
 # Now build the code
-RUN npm install -g npm@5.6.0
 RUN cd ${APP_ROOT}/frontend && npm install
 RUN cd ${APP_ROOT}/frontend && npm run build
 ADD docker-entrypoint.sh ${APP_ROOT}/docker-entrypoint.sh

--- a/Dockerfile-cicd
+++ b/Dockerfile-cicd
@@ -12,22 +12,9 @@ RUN apt-get install -y wget gnupg bzip2
 ARG FE_GIT_PROJECT=xchem
 RUN git clone https://github.com/${FE_GIT_PROJECT}/fragalysis-frontend ${APP_ROOT}/frontend
 
-# Now add npm
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+# Now add nodejs/npm
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install -y nodejs
-# Now build the code.
-#
-# Note (abc): Use of npm v5.6.0 turned out to be crucial in fixing the build.
-#             The change was introduced in response to receiving the error
-#             "npm ERR! cb() never called!" when building in the OpenShift
-#             cluster with buildah 1.1 when using the docker and
-#             internal-registry backend. Building with Docker, outside the
-#             cluster, was error-free.
-#
-#             See: https://stackoverflow.com/questions/15393821/npm-err-cb-never-called
-#             Specifically the comment from Sukhdeep Sing (Oct 24 '16)
-#
-RUN npm install -g npm@5.6.0
 RUN cd ${APP_ROOT}/frontend && npm install
 RUN cd ${APP_ROOT}/frontend && npm run build
 ADD docker-entrypoint.sh ${APP_ROOT}/docker-entrypoint.sh


### PR DESCRIPTION
The loss of 'npm' is obscure. A work-around seems to be to move to node.js 10. This change moves to node.js 10 and removed the reversion of npm to 5.6.0 (required for an earlier problem).

Changes impact the main Dockerfile and the ci/cd Dockerfile