### PR TITLE
- Uses DOCKER_USER from credential store

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,9 @@ pipeline {
     REGISTRY = 'docker-registry.default.svc:5000'
     // Destination image (pushed to docker hub)
     IMAGE = 'xchem/fragalysis-stack'
-    DOCKER_USER = 'alanbchristie'
+
+    // Docker hub credentials
+    DOCKER_USER = credentials('abcDockerUser')
     DOCKER_PASSWORD = credentials('abcDockerPassword')
 
     // Slack channel for all notifications


### PR DESCRIPTION
The docker-user was hard-coded. This small change to the CICD Jenkinsfile, utilised in the OpenShift deployment, pulls the docker user from the Jenkins credential store.