### PR TITLE
add missing python library files for rdkit error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV APP_USER_ID 2000
 RUN useradd -c 'Container user' --user-group --uid ${APP_USER_ID} --home-dir ${APP_ROOT} -s /bin/bash frag
 
 RUN apt-get update -y
-RUN apt-get install -y wget gnupg bzip2
+RUN apt-get install -y wget gnupg bzip2 libboost-python1.62.0
 # Add in the frontend code
 RUN git clone https://github.com/xchem/fragalysis-frontend ${APP_ROOT}/frontend
 # Now add npm


### PR DESCRIPTION
ImportError: libboost_python-py27.so.1.62.0: cannot open shared object file: No such file or directory