### PR TITLE
- A fix for image builds that are not 'latest'

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
       }
       steps {
         sh "podman login --username ${DOCKER_USER} --password ${DOCKER_PASSWORD} docker.io"
-        sh "buildah push ${IMAGE} docker://docker.io/${IMAGE}:${IMAGE_TAG}"
+        sh "buildah push ${IMAGE}:${IMAGE_TAG} docker://docker.io/${IMAGE}:${IMAGE_TAG}"
         sh "podman logout docker.io"
       }
     }


### PR DESCRIPTION
- This is required to create user/project-specific stack images

A bug in the Jenkinsfile means that you're not able to build stack images other than 'latest', something supported in other parts of the Jenkinsfile. This is separate from the backend _origin_ flaw, which (at the moment) is hard-coded into the Dockerfile-cicd.