### PR TITLE
Adds ability to clone from a branch of the frontend

### DIFF
--- a/Dockerfile-cicd
+++ b/Dockerfile-cicd
@@ -7,10 +7,11 @@ RUN apt-get update -y
 RUN apt-get install -y wget gnupg bzip2
 
 # Add in the frontend code
-# By default this is hosted in the xchem project
-# but it can be redirected.
+# By default this is hosted in the xchem project's master branch
+# but it can be redirected...
 ARG FE_GIT_PROJECT=xchem
-RUN git clone https://github.com/${FE_GIT_PROJECT}/fragalysis-frontend ${APP_ROOT}/frontend
+ARG FE_GIT_PROJECT_BRANCH=master
+RUN git clone -b ${FE_GIT_PROJECT_BRANCH} --single-branch https://github.com/${FE_GIT_PROJECT}/fragalysis-frontend ${APP_ROOT}/frontend
 
 # Install yarn (instead of npm)
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -


### PR DESCRIPTION
- This tweak allows the stack CI/CD build process to clone a specific branch from a frontend repo.
  Adds the build variable FE_GIT_PROJECT_BRANCH
  Prior to this only the matter branch was cloned
  Default behaviour is to clone the master branch
- Changes affect the Jenkins/CI/CD build
